### PR TITLE
Switch to determisistic course id to be stable aceoss rescrapes and rebuilds

### DIFF
--- a/prisma/migrations/20260902000000_deterministic_course_id/migration.sql
+++ b/prisma/migrations/20260902000000_deterministic_course_id/migration.sql
@@ -1,0 +1,24 @@
+-- Switch Course.id from autoincrement (SERIAL int4) to a deterministic integer id:
+-- {year:4}{semester:1}{courseCode:7}{group:2}{unitCount:1}
+-- e.g. year 1405, semester 1, code 40424, group 1, units 3 => 140510040424013
+-- This makes ids stable across database rebuilds/rescrapes.
+
+-- 1) Detach Course.id from its autoincrement default (SERIAL / IDENTITY)
+ALTER TABLE "Course" ALTER COLUMN "id" DROP DEFAULT;
+ALTER TABLE "Course" ALTER COLUMN "id" DROP IDENTITY IF EXISTS;
+
+-- 2) Drop the sessions FK before changing column types
+ALTER TABLE "CourseSession" DROP CONSTRAINT IF EXISTS "CourseSession_courseId_fkey";
+
+-- 3) Widen id columns to BIGINT (no-ops if already BIGINT)
+ALTER TABLE "Course" ALTER COLUMN "id" TYPE BIGINT;
+ALTER TABLE "Course" ALTER COLUMN "id" SET NOT NULL;
+ALTER TABLE "CourseSession" ALTER COLUMN "courseId" TYPE BIGINT;
+ALTER TABLE "CourseSession" ALTER COLUMN "courseId" SET NOT NULL;
+
+-- 4) Remove the now-unused autoincrement sequence
+ALTER SEQUENCE IF EXISTS "Course_id_seq" OWNED BY NONE;
+DROP SEQUENCE IF EXISTS "Course_id_seq";
+
+-- 5) Re-add the FK upgraded to ON DELETE CASCADE (matches schema.prisma)
+ALTER TABLE "CourseSession" ADD CONSTRAINT "CourseSession_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -29,7 +29,7 @@ model Professor {
 }
 
 model Course {
-    id                   Int            @id @default(autoincrement())
+    id                   BigInt         @id
     courseName           String
     courseCode           String
     unitCount            Int
@@ -60,8 +60,8 @@ model Course {
 
 model CourseSession {
     id         Int     @id @default(autoincrement())
-    courseId   Int
-    course     Course  @relation(fields: [courseId], references: [id])
+    courseId   BigInt
+    course     Course  @relation(fields: [courseId], references: [id], onDelete: Cascade)
     dayOfWeek  Int
     startTime  String
     endTime    String

--- a/src/pages/api/admin/populate.ts
+++ b/src/pages/api/admin/populate.ts
@@ -30,6 +30,26 @@ type Course = {
 
 type CoursesResponse = Record<string, Course>;
 
+// {year:4}{semester:1}{courseCode:7}{group:2}{unitCount:1}
+// year 1403, semester 1, code 40424, group 1, units 3 => 140310040424013
+const buildCourseId = (
+  courseCode: string,
+  group: number,
+  unitCount: number,
+  year: number,
+  semester: number,
+): bigint => {
+  const code = Number(courseCode);
+  if (!Number.isSafeInteger(code) || code < 0 || code >= 1e7) {
+    throw new Error(`Unsupported course code: ${courseCode}`);
+  }
+  if (group < 0 || group > 99) throw new Error(`Unsupported group: ${group}`);
+  if (unitCount < 0 || unitCount > 9) throw new Error(`Unsupported units: ${unitCount}`);
+  if (year < 0 || year > 9999) throw new Error(`Unsupported year: ${year}`);
+  if (semester < 0 || semester > 9) throw new Error(`Unsupported semester: ${semester}`);
+  return BigInt((((year * 10 + semester) * 10000000 + code) * 100 + group) * 10 + unitCount);
+};
+
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== "POST") {
     res.setHeader("Allow", ["POST"]);
@@ -85,7 +105,16 @@ export const populate = async (): Promise<boolean> => {
       }
 
       // Step 5: Create or update the Course
-      const course = await db.course.upsert({
+      const courseId = buildCourseId(
+        courseCode,
+        courseData.Group,
+        courseData.Units,
+        courseData.Year,
+        courseData.Semester,
+      );
+
+      // Find and drop stale row if exists
+      const existingCourse = await db.course.findUnique({
         where: {
           courseCode_group_year_semester: {
             courseCode: courseCode,
@@ -94,6 +123,13 @@ export const populate = async (): Promise<boolean> => {
             semester: courseData.Semester,
           },
         },
+      });
+      if (existingCourse && existingCourse.id !== courseId) {
+        await db.course.delete({ where: { id: existingCourse.id } });
+      }
+
+      const course = await db.course.upsert({
+        where: { id: courseId },
         update: {
           courseName: courseData.Name,
           unitCount: courseData.Units,
@@ -108,6 +144,7 @@ export const populate = async (): Promise<boolean> => {
           grade: courseData.Grade,
         },
         create: {
+          id: courseId,
           courseCode: courseCode,
           courseName: courseData.Name,
           unitCount: courseData.Units,

--- a/src/server/api/routers/course.ts
+++ b/src/server/api/routers/course.ts
@@ -3,7 +3,7 @@ import { createTRPCRouter, publicProcedure } from "@/server/api/trpc";
 
 export const courseRouter = createTRPCRouter({
   getCoursesByIds: publicProcedure
-    .input(z.object({ courseIds: z.array(z.number()) }))
+    .input(z.object({ courseIds: z.array(z.number().int()) }))
     .query(async ({ ctx, input }) => {
       const result = await ctx.db.course.findFirst({
         select: {
@@ -19,10 +19,10 @@ export const courseRouter = createTRPCRouter({
 
       const { year, semester } = result;
 
-      return ctx.db.course.findMany({
+      const courses = await ctx.db.course.findMany({
         where: {
           id: {
-            in: input.courseIds,
+            in: input.courseIds.map((id) => BigInt(id)),
           },
           year,
           semester,
@@ -32,5 +32,14 @@ export const courseRouter = createTRPCRouter({
           courseSessions: true,
         },
       });
+
+      return courses.map((course) => ({
+        ...course,
+        id: Number(course.id),
+        courseSessions: course.courseSessions.map((session) => ({
+          ...session,
+          courseId: Number(session.courseId),
+        })),
+      }));
     }),
 });


### PR DESCRIPTION
A problem that always occurred after purging and rescraping the course database was that the course ids got mixed up, resulting in strange and unrelated courses being displayed in the client.

This Pull Request was created in this regard. In this PR, the id value is generated from a deterministic combination of a course's specifications instead of auto incrementing, so that it remains constant and the same across rebuilds and rescrapes.

## ID format:
{year:4}{semester:1}{courseCode:7}{group:2}{unitCount:1}
e.g. year 1405, semester 1, code 40424, group 1, units 3 => 140510040424013